### PR TITLE
[DW-2566] W3C error frameborder attribute in iframe deprecated put in…

### DIFF
--- a/src/nhsd/components/organisms/banner/_index.scss
+++ b/src/nhsd/components/organisms/banner/_index.scss
@@ -96,6 +96,6 @@ $-breakpoints: "xs", "s", "m", "l", "xl";
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    border: none;
   }
 }

--- a/src/nhsd/components/organisms/banner/_index.scss
+++ b/src/nhsd/components/organisms/banner/_index.scss
@@ -96,6 +96,7 @@ $-breakpoints: "xs", "s", "m", "l", "xl";
     top: 0;
     left: 0;
     width: 100%;
+    height: 100%;
     border: none;
   }
 }


### PR DESCRIPTION
hi @LEJA3 this is relating to ticket DW-2566. It seems according to W3C iframe attribute frameborder is deprecated, and recommends putting this in the CSS, as border: none. I checked with toolkit and it does not seem to throw any complaints or errors. However, this has not been formally tested by @naimullakhan1. Your advice is welcomed to what the best practice should be. I have made the small change which is to add the said border: none to the class effected. KR